### PR TITLE
Make gms module usable again with Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,34 +1,61 @@
-image: "ruby:2.4.5"
-
+---
 cache:
   paths:
     - vendor/ruby
     - spec/fixtures
 
 variables:
+
+.puppet400: &puppet400
+  PUPPET_LOCATION: 4.0.0
+  BUNDLER: '1.7.3'
+
+.puppet41012: &puppet41012
   PUPPET_LOCATION: 4.10.12
+  BUNDLER: '1.7.3'
 
-before_script:
-  - gem install bundler  --no-document
-  - bundle install -j $(nproc) --path vendor
+.puppet550: &puppet550
+  PUPPET_LOCATION: 5.5.0
+  BUNDLER: '>= 0'
 
-test-syntax:
-  stage: test
+.syntax: &syntax
   script:
   - bundle exec rake syntax
 
-test-validate:
-  stage: test
+.validate: &validate
   script:
   - bundle exec rake validate
 
-test-lint:
-  stage: test
+.lint: &lint
   script:
   - bundle exec rake lint
 
-test-rspec:
-  stage: test
+.spec: &spec
   script:
   - bundle exec rake spec SPEC_OPTS='--format documentation'
   coverage: '/Resource coverage: \d+\.\d+/'
+
+before_script:
+  - gem install bundler --no-document --version "$BUNDLER"
+  - bundle install -j $(nproc) --path vendor --without development acceptance
+
+puppet41012_test:
+  stage: test
+  image: "ruby:2.1.9"
+  <<: [*syntax, *validate, *lint, *spec]
+  variables:
+    <<: [*puppet41012]
+
+puppet550_test:
+  image: "ruby:2.4.5"
+  stage: test
+  <<: [*syntax, *validate, *lint, *spec]
+  variables:
+    <<: [*puppet550]
+
+puppet400_test:
+  stage: test
+  image: "ruby:2.1.9"
+  <<: [*syntax, *validate, *lint, *spec]
+  variables:
+    <<: [*puppet400]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+image: "ruby:2.4.5"
+
+cache:
+  paths:
+    - vendor/ruby
+    - spec/fixtures
+
+variables:
+  PUPPET_LOCATION: 4.10.12
+
+before_script:
+  - gem install bundler  --no-document
+  - bundle install -j $(nproc) --path vendor
+
+test-syntax:
+  stage: test
+  script:
+  - bundle exec rake syntax
+
+test-validate:
+  stage: test
+  script:
+  - bundle exec rake validate
+
+test-lint:
+  stage: test
+  script:
+  - bundle exec rake lint
+
+test-rspec:
+  stage: test
+  script:
+  - bundle exec rake spec SPEC_OPTS='--format documentation'
+  coverage: '/Resource coverage: \d+\.\d+/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ script:
   - "bundle exec rake syntax"
   - "bundle exec rake spec SPEC_OPTS='--format documentation'"
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.4.5
 env:
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
@@ -24,15 +24,10 @@ env:
   - PUPPET_VERSION="~> 3.6.0"
   - PUPPET_VERSION="~> 3.7.0"
   - PUPPET_VERSION="~> 4.0.0"
+  - PUPPET_VERSION="~> 5.5.0"
 
 global:
   - PUBLISHER_LOGIN=abrader
 
 notifications:
   email: false
-  webhooks:
-    urls:
-      - 'https://webhooks.gitter.im/e/16f24db0492933fce79d' 
-    on_success: change
-    on_failure: always
-    on_start: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,21 @@ rvm:
   - 2.2
   - 2.4.5
 env:
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.1"
-  - PUPPET_VERSION="~> 3.6.0"
-  - PUPPET_VERSION="~> 3.7.0"
-  - PUPPET_VERSION="~> 4.0.0"
-  - PUPPET_VERSION="~> 5.5.0"
+  - PUPPET_LOCATION="~> 3.4.0"
+  - PUPPET_LOCATION="~> 3.5.1"
+  - PUPPET_LOCATION="~> 3.6.0"
+  - PUPPET_LOCATION="~> 3.7.0"
+  - PUPPET_LOCATION="~> 4.0.0"
+  - PUPPET_LOCATION="~> 5.5.0"
+matrix:
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_LOCATION="~> 3.2.0"
+  - rvm: 2.0.0
+    env: PUPPET_LOCATION="~> 3.3.0"
 
 global:
-  - PUBLISHER_LOGIN=abrader
+  - PUBLISHER_LOGIN=bjvrielink
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,21 @@ env:
   - PUPPET_LOCATION="~> 3.6.0"
   - PUPPET_LOCATION="~> 3.7.0"
   - PUPPET_LOCATION="~> 4.0.0"
-  - PUPPET_LOCATION="~> 5.5.0"
 matrix:
   include:
-  - rvm: 1.9.3
-    env: PUPPET_LOCATION="~> 3.2.0"
   - rvm: 2.0.0
     env: PUPPET_LOCATION="~> 3.3.0"
+  - rvm: 2.4.5
+    env: PUPPET_LOCATION="~> 5.5.0"
 
 global:
-  - PUBLISHER_LOGIN=bjvrielink
+  - PUBLISHER_LOGIN=abrader
 
 notifications:
   email: false
+  webhooks:
+    urls:
+      - 'https://webhooks.gitter.im/e/16f24db0492933fce79d' 
+    on_success: change
+    on_failure: always
+    on_start: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 group :test do
   gem 'rake'
-  gem 'puppet', *location_for(ENV['PUPPET_LOCATION'] || '~> 5.5.0')
+  gem 'puppet', *location_for(ENV['PUPPET_LOCATION'] || '~> 3.7.0')
   gem 'puppetlabs_spec_helper'
   gem 'webmock'
   gem 'vcr'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 group :test do
   gem 'rake'
-  gem 'puppet', *location_for(ENV['PUPPET_LOCATION'] || '~> 3.7.0')
+  gem 'puppet', *location_for(ENV['PUPPET_LOCATION'] || '~> 5.5.0')
   gem 'puppetlabs_spec_helper'
   gem 'webmock'
   gem 'vcr'

--- a/lib/puppet/provider/git_deploy_key/gitlab.rb
+++ b/lib/puppet/provider/git_deploy_key/gitlab.rb
@@ -13,6 +13,18 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
     return 'https://gitlab.com'
   end
 
+  def api_version
+    return resource[:gitlab_api_version]
+  end
+
+  def keys_endpoint
+    if api_version.to_s.eql? "v3"
+      return 'keys'
+    else
+      return 'deploy_keys'
+    end
+  end
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -69,7 +81,8 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
     project_id = get_project_id
 
     sshkey_hash = Hash.new
-    url = "#{gms_server}/api/v3/projects/#{project_id}/keys"
+
+    url = "#{gms_server}/api/#{api_version}/projects/#{project_id}/#{keys_endpoint}"
 
     response = api_call('GET', url)
 
@@ -98,7 +111,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
 
     project_name = resource[:project_name].strip.gsub('/','%2F')
 
-    url = "#{gms_server}/api/v3/projects/#{project_name}"
+    url = "#{gms_server}/api/#{api_version}/projects/#{project_name}"
 
     begin
       response = api_call('GET', url)
@@ -115,7 +128,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
 
     keys_hash = Hash.new
 
-    url = "#{gms_server}/api/v3/projects/#{project_id}/keys"
+    url = "#{gms_server}/api/#{api_version}/projects/#{project_id}/#{keys_endpoint}"
 
     response = api_call('GET', url)
 
@@ -138,7 +151,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
   def create
     project_id = get_project_id
 
-    url = "#{gms_server}/api/v3/projects/#{project_id}/keys"
+    url = "#{gms_server}/api/#{api_version}/projects/#{project_id}/#{keys_endpoint}"
 
     begin
       response = api_call('POST', url, {'title' => resource[:name].strip, 'key' => File.read(resource[:path].strip)})
@@ -159,7 +172,8 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
     key_id = get_key_id
 
     unless key_id.nil?
-      url = "#{gms_server}/api/v3/projects/#{project_id}/keys/#{key_id}"
+
+      url = "#{gms_server}/api/#{api_version}/projects/#{project_id}/#{keys_endpoint}/#{key_id}"
 
       begin
         response = api_call('DELETE', url)
@@ -177,5 +191,3 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
   end
 
 end
-
-

--- a/lib/puppet/provider/git_deploy_key/gitlab.rb
+++ b/lib/puppet/provider/git_deploy_key/gitlab.rb
@@ -96,7 +96,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
       raise(Puppet::Error, "gitlab_deploy_key::#{calling_method}: Must provide at least one of the following attributes: project_id or project_name")
     end
 
-    project_name = resource[:project_name].strip.sub('/','%2F')
+    project_name = resource[:project_name].strip.gsub('/','%2F')
 
     url = "#{gms_server}/api/v3/projects/#{project_name}"
 

--- a/lib/puppet/provider/git_groupteam/gitlab.rb
+++ b/lib/puppet/provider/git_groupteam/gitlab.rb
@@ -13,6 +13,10 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
     return 'https://gitlab.com'
   end
 
+  def api_version
+    return resource[:gitlab_api_version]
+  end
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -67,7 +71,7 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
 
   def exists?
     groupteam_hash = Hash.new
-    url = "#{gms_server}/api/v3/groups"
+    url = "#{gms_server}/api/#{api_version}/groups"
 
     response = api_call('GET', url)
 
@@ -96,7 +100,7 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
   def get_group_id
     group_hash = Hash.new
 
-    url = "#{gms_server}/api/v3/groups"
+    url = "#{gms_server}/api/#{api_version}/groups"
 
     response = api_call('GET', url)
 
@@ -117,7 +121,7 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
   end
 
   def create
-    url = "#{gms_server}/api/v3/groups"
+    url = "#{gms_server}/api/#{api_version}/groups"
 
     begin
       opts = { 'name' => resource[:groupteam_name].strip, 'path' => resource[:groupteam_name].strip }
@@ -144,7 +148,7 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
     group_id = get_group_id
 
     unless group_id.nil?
-      url = "#{gms_server}/api/v3/groups/#{group_id}"
+      url = "#{gms_server}/api/#{api_version}/groups/#{group_id}"
 
       begin
         response = api_call('DELETE', url)
@@ -162,5 +166,3 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
   end
 
 end
-
-

--- a/lib/puppet/provider/git_groupteam_member/gitlab.rb
+++ b/lib/puppet/provider/git_groupteam_member/gitlab.rb
@@ -19,6 +19,10 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     return 'https://gitlab.com'
   end
 
+  def api_version
+    return resource[:gitlab_api_version]
+  end
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -76,7 +80,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     group_id = get_group_id
 
     groupteam_hash = Hash.new
-    url = "#{gms_server}/api/v3//groups/#{group_id}/members"
+    url = "#{gms_server}/api/#{api_version}/groups/#{group_id}/members"
 
     response = api_call('GET', url)
 
@@ -130,7 +134,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
   def get_group_id
     group_hash = Hash.new
 
-    url = "#{gms_server}/api/v3/groups?search=#{resource[:groupteam_name].strip}"
+    url = "#{gms_server}/api/#{api_version}/groups?search=#{resource[:groupteam_name].strip}"
 
     response = api_call('GET', url)
 
@@ -153,7 +157,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
   def get_user_id
     group_hash = Hash.new
 
-    url = "#{gms_server}/api/v3/users?search=#{resource[:member_name].strip}"
+    url = "#{gms_server}/api/#{api_version}/users?search=#{resource[:member_name].strip}"
 
     response = api_call('GET', url)
 
@@ -178,7 +182,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     group_id = get_group_id
     user_id  = get_user_id
 
-    url = "#{gms_server}/api/v3//groups/#{group_id}/members"
+    url = "#{gms_server}/api/#{api_version}/groups/#{group_id}/members"
 
     begin
       if access_level.nil? ||  group_id.nil? || user_id.nil?
@@ -206,7 +210,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     user_id  = get_user_id
 
     unless group_id.nil?
-      url = "#{gms_server}/api/v3//groups/#{group_id}/members/#{user_id}"
+      url = "#{gms_server}/api/#{api_version}//groups/#{group_id}/members/#{user_id}"
 
       begin
         response = api_call('DELETE', url)
@@ -224,5 +228,3 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
   end
 
 end
-
-

--- a/lib/puppet/provider/git_webhook/gitlab.rb
+++ b/lib/puppet/provider/git_webhook/gitlab.rb
@@ -13,6 +13,10 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
     return 'https://gitlab.com'
   end
 
+  def api_version
+    return resource[:gitlab_api_version]
+  end
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -69,7 +73,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
     project_id = get_project_id
 
     webhook_hash = Hash.new
-    url = "#{gms_server}/api/v3/projects/#{project_id}/hooks"
+    url = "#{gms_server}/api/#{api_version}/projects/#{project_id}/hooks"
 
     response = api_call('GET', url)
 
@@ -99,7 +103,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
 
     project_name = resource[:project_name].strip.sub('/','%2F')
 
-    url = "#{gms_server}/api/v3/projects/#{project_name}"
+    url = "#{gms_server}/api/#{api_version}/projects/#{project_name}"
 
     begin
       response = api_call('GET', url)
@@ -116,7 +120,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
 
     webhook_hash = Hash.new
 
-    url = "#{gms_server}/api/v3/projects/#{project_id}/hooks"
+    url = "#{gms_server}/api/#{api_version}/projects/#{project_id}/hooks"
 
     response = api_call('GET', url)
 
@@ -138,7 +142,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
   def create
     project_id = get_project_id
 
-    url = "#{gms_server}/api/v3/projects/#{project_id}/hooks"
+    url = "#{gms_server}/api/#{api_version}/projects/#{project_id}/hooks"
 
     begin
       opts = { 'url' => resource[:webhook_url].strip }
@@ -181,7 +185,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
     webhook_id = get_webhook_id
 
     unless webhook_id.nil?
-      url = "#{gms_server}/api/v3/projects/#{project_id}/hooks/#{webhook_id}"
+      url = "#{gms_server}/api/#{api_version}/projects/#{project_id}/hooks/#{webhook_id}"
 
       begin
         response = api_call('DELETE', url)
@@ -199,5 +203,3 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
   end
 
 end
-
-

--- a/lib/puppet/provider/git_webhook/gitlab.rb
+++ b/lib/puppet/provider/git_webhook/gitlab.rb
@@ -101,7 +101,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
       raise(Puppet::Error, "gitlab_webhook::#{calling_method}: Must provide at least one of the following attributes: project_id or project_name")
     end
 
-    project_name = resource[:project_name].strip.sub('/','%2F')
+    project_name = resource[:project_name].strip.gsub('/','%2F')
 
     url = "#{gms_server}/api/#{api_version}/projects/#{project_name}"
 

--- a/lib/puppet/provider/gms_webhook/gitlab.rb
+++ b/lib/puppet/provider/gms_webhook/gitlab.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:gms_webhook).provide(:gitlab, :parent => PuppetX::Puppetlabs:
 
     instances = []
 
-    repos_url = "#{gms_server}/api/v3/projects"
+    repos_url = "#{gms_server}/api/#{api_version}/projects"
     repos = get(repos_url, @token)
 
     webhooks = Array.new
@@ -37,7 +37,7 @@ Puppet::Type.type(:gms_webhook).provide(:gitlab, :parent => PuppetX::Puppetlabs:
     repos.each do |r|
 
       # hooks_url = "#{gms_server}/projects/#{r['id']}/hooks"
-      hooks_url = "#{gms_server}/api/v3/projects/#{r['id']}/hooks"
+      hooks_url = "#{gms_server}/api/#{api_version}/projects/#{r['id']}/hooks"
 
       hook_objs = get(hooks_url, @token)
 
@@ -126,6 +126,10 @@ Puppet::Type.type(:gms_webhook).provide(:gitlab, :parent => PuppetX::Puppetlabs:
     PuppetX::Puppetlabs::Gms::gms_server
   end
 
+  def api_version
+    return resource[:gitlab_api_version]
+  end
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -137,7 +141,7 @@ Puppet::Type.type(:gms_webhook).provide(:gitlab, :parent => PuppetX::Puppetlabs:
 
   def get_project_id(project_name)
     begin
-      repos_url = "#{self.gms_server}/api/v3/projects"
+      repos_url = "#{self.gms_server}/api/#{api_version}/projects"
       repos = PuppetX::Puppetlabs::Gms.get(repos_url, get_token)
 
       repos.each do |r|
@@ -158,7 +162,7 @@ Puppet::Type.type(:gms_webhook).provide(:gitlab, :parent => PuppetX::Puppetlabs:
   def flush
     Puppet.debug("def flush")
 
-    put_url = "#{gms_server}/api/v3/projects/#{get_project_id(resource[:project_name].strip)}/hooks/#{self.id}"
+    put_url = "#{gms_server}/api/#{api_version}/projects/#{get_project_id(resource[:project_name].strip)}/hooks/#{self.id}"
 
     if @property_hash != {}
       begin
@@ -179,7 +183,7 @@ Puppet::Type.type(:gms_webhook).provide(:gitlab, :parent => PuppetX::Puppetlabs:
     Puppet.debug('def create')
 
     begin
-      post_url = "#{self.gms_server}/api/v3/projects/#{get_project_id(resource[:project_name].strip)}/hooks"
+      post_url = "#{self.gms_server}/api/#{api_version}/projects/#{get_project_id(resource[:project_name].strip)}/hooks"
 
       response = PuppetX::Puppetlabs::Gms.post(post_url, get_token, message(resource))
 
@@ -202,7 +206,7 @@ Puppet::Type.type(:gms_webhook).provide(:gitlab, :parent => PuppetX::Puppetlabs:
     Puppet.debug("def destroy")
 
     unless webhook_id.nil?
-      destroy_url = "#{gms_server}/api/v3/projects/#{get_project_id(resource[:project_name].strip)}/hooks/#{self.id}"
+      destroy_url = "#{gms_server}/api/#{api_version}/projects/#{get_project_id(resource[:project_name].strip)}/hooks/#{self.id}"
 
       begin
         response = PuppetX::Puppetlabs::Gms.delete(destroy_url, get_token)

--- a/lib/puppet/type/git_deploy_key.rb
+++ b/lib/puppet/type/git_deploy_key.rb
@@ -61,6 +61,12 @@ module Puppet
       end
     end
 
+    newparam(:gitlab_api_version) do
+      desc 'The api version to use with gitlab.'
+      defaultto :v4
+      newvalues(:v3, :v4)
+    end
+
     autorequire(:file) do
       self[:path]if self[:path] and Pathname.new(self[:path]).absolute?
     end
@@ -71,4 +77,3 @@ module Puppet
 
   end
 end
-

--- a/lib/puppet/type/git_groupteam.rb
+++ b/lib/puppet/type/git_groupteam.rb
@@ -99,10 +99,15 @@ module Puppet
       end
     end
 
+    newparam(:gitlab_api_version) do
+      desc 'The api version to use with gitlab.'
+      defaultto :v4
+      newvalues(:v3, :v4)
+    end
+
     validate do
       validate_token_or_token_file
     end
 
   end
 end
-

--- a/lib/puppet/type/git_groupteam_member.rb
+++ b/lib/puppet/type/git_groupteam_member.rb
@@ -106,10 +106,15 @@ module Puppet
       end
     end
 
+    newparam(:gitlab_api_version) do
+      desc 'The api version to use with gitlab.'
+      defaultto :v4
+      newvalues(:v3, :v4)
+    end
+
     validate do
       validate_token_or_token_file
     end
 
   end
 end
-

--- a/lib/puppet/type/git_webhook.rb
+++ b/lib/puppet/type/git_webhook.rb
@@ -100,10 +100,15 @@ module Puppet
       end
     end
 
+    newparam(:gitlab_api_version) do
+      desc 'The api version to use with gitlab.'
+      defaultto :v4
+      newvalues(:v3, :v4)
+    end
+
     validate do
       validate_token_or_token_file
     end
 
   end
 end
-

--- a/lib/puppet/type/gms_webhook.rb
+++ b/lib/puppet/type/gms_webhook.rb
@@ -178,6 +178,12 @@ Puppet::Type.newtype(:gms_webhook) do
     end
   end
 
+  newparam(:gitlab_api_version) do
+    desc 'The api version to use with gitlab.'
+    defaultto :v4
+    newvalues(:v3, :v4)
+  end
+
   read_only_properties = {
     id:                    'id',
     last_response_code:    'last_response_code',

--- a/metadata.json
+++ b/metadata.json
@@ -81,18 +81,14 @@
    ],
    "requirements": [
        {
-         "name": "pe",
-         "version_requirement": ">= 3.1.3 < 2015.4.0"
-       },
-       {
          "name": "puppet",
-         "version_requirement": ">= 3.4.3 < 5.0.0"
+         "version_requirement": ">= 3.4.3 < 6.0.0"
        }
      ],
    "dependencies": [
      {
        "name": "puppetlabs/stdlib",
-       "version_requirement": ">=3.2.0 <5.0.0"
+       "version_requirement": ">=3.2.0 <6.0.0"
      }
    ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -82,13 +82,13 @@
    "requirements": [
        {
          "name": "puppet",
-         "version_requirement": ">= 3.4.3 < 6.0.0"
+         "version_requirement": ">= 3.4.3 < 7.0.0"
        }
      ],
    "dependencies": [
      {
        "name": "puppetlabs/stdlib",
-       "version_requirement": ">=3.2.0 <6.0.0"
+       "version_requirement": ">=3.2.0 <7.0.0"
      }
    ]
 }


### PR DESCRIPTION
- Updated Travis (dropped ancient Ruby version, added newer Ruby and Puppet versions)
- Added patch for submodules in Gitlab (ricou84)
- Added patch to make Gitlab Api version configurable (mstinsky)
- Added gitlab-ci config
- Updated metadata.json dependencies
- Updated default Puppet version in Gemfile